### PR TITLE
Add annotation processor

### DIFF
--- a/publisher.gradle
+++ b/publisher.gradle
@@ -1,4 +1,3 @@
-
 class PublishPluginExtension {
     String description = "Yet Another JSON RPC (YAJ-RPC) is a JSON RPC 2.0 implementation for JVM languages written in Kotlin"
 }
@@ -20,6 +19,7 @@ class PublishPlugin implements Plugin<Project>{
     }
 
     void apply(Project project) {
+        def extension = project.extensions.create('pomDescription', PublishPluginExtension)
         if (project.hasProperty("ossrhUsername") && project.hasProperty("ossrhPassword")) {
 
             project.apply(plugin: MavenPublishPlugin)
@@ -31,7 +31,6 @@ class PublishPlugin implements Plugin<Project>{
 
             println("maven version for ${project.archivesBaseName} is: ${project.version}")
 
-            def extension = project.extensions.create('pomDescription', PublishPluginExtension)
 
             project.publishing {
                 publications {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,4 +6,4 @@ include 'yaj-rpc-zmq'
 include 'yaj-rpc-tcp'
 include 'yaj-rpc-http'
 include 'yaj-rpc-tests'
-
+include 'yaj-rpc-annotation-processor'

--- a/yaj-rpc-annotation-processor/build.gradle
+++ b/yaj-rpc-annotation-processor/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id "org.jetbrains.kotlin.kapt"
+}
+
+apply from: rootProject.file("publisher.gradle")
+
+dependencies {
+    api project(':yaj-rpc')
+    implementation "com.google.auto.service:auto-service:1.0-rc4"
+    implementation 'com.squareup:kotlinpoet:1.0.0-RC2'
+    kapt "com.google.auto.service:auto-service:1.0-rc4"
+}
+
+pomDescription {
+    description = "Annotation processors for YAJ RPC"
+}

--- a/yaj-rpc-annotation-processor/src/main/kotlin/info/laht/yajrpc/annotationprocessor/Processor.kt
+++ b/yaj-rpc-annotation-processor/src/main/kotlin/info/laht/yajrpc/annotationprocessor/Processor.kt
@@ -79,9 +79,8 @@ class GenerateWrappersProcessor : AbstractProcessor() {
                 builder.addType(type.build())
             }
 
-            val outputFile = File("$kaptKotlinGeneratedDir/info/laht/yajrpc/Wrappers.kt")
-            outputFile.parentFile.mkdirs()
-            builder.build().writeTo(outputFile)
+            val outputDirectory = File(kaptKotlinGeneratedDir)
+            builder.build().writeTo(outputDirectory)
         }
         return true
     }

--- a/yaj-rpc-annotation-processor/src/main/kotlin/info/laht/yajrpc/annotationprocessor/Processor.kt
+++ b/yaj-rpc-annotation-processor/src/main/kotlin/info/laht/yajrpc/annotationprocessor/Processor.kt
@@ -1,0 +1,110 @@
+package info.laht.yajrpc.annotationprocessor
+
+import com.google.auto.service.AutoService
+import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import info.laht.yajrpc.RpcMethod
+import info.laht.yajrpc.net.RpcClient
+import java.io.File
+import javax.annotation.processing.*
+import javax.lang.model.SourceVersion
+import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.TypeElement
+import javax.lang.model.type.TypeKind
+import javax.tools.Diagnostic
+import kotlin.reflect.jvm.internal.impl.builtins.jvm.JavaToKotlinClassMap
+import kotlin.reflect.jvm.internal.impl.name.FqName
+
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class GenerateRpcWrapper(val serviceName : String = "")
+
+@AutoService(Processor::class)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedAnnotationTypes("info.laht.yajrpc.annotationprocessor.GenerateRpcWrapper")
+@SupportedOptions(GenerateWrappersProcessor.KAPT_KOTLIN_GENERATED_OPTION_NAME)
+class GenerateWrappersProcessor : AbstractProcessor() {
+    companion object {
+        const val KAPT_KOTLIN_GENERATED_OPTION_NAME = "kapt.kotlin.generated"
+    }
+    override fun process(annotations: MutableSet<out TypeElement>, roundEnv: RoundEnvironment): Boolean {
+        val elements = roundEnv.getElementsAnnotatedWith(GenerateRpcWrapper::class.java)
+        val kaptKotlinGeneratedDir = processingEnv.options[KAPT_KOTLIN_GENERATED_OPTION_NAME] ?: run {
+            processingEnv.messager.printMessage(Diagnostic.Kind.ERROR, "Can't find the target directory for generated Kotlin files.")
+            return false
+        }
+
+        if(elements.isNotEmpty()){
+            val builder = FileSpec.builder("info.laht.yajrpc", "Wrappers")
+
+            for(element in elements){
+                val type = TypeSpec.classBuilder("${element.simpleName}Wrapper")
+                type.primaryConstructor(FunSpec.constructorBuilder()
+                    .addParameter("client", RpcClient::class)
+                    .build())
+                type.addProperty(PropertySpec.builder("client", RpcClient::class)
+                    .initializer("client")
+                    .addModifiers(KModifier.PRIVATE)
+                    .build()
+                )
+                val wrapperOptions = element.getAnnotation(GenerateRpcWrapper::class.java)
+                val methods = element.enclosedElements
+                    .filter { it.kind == ElementKind.METHOD && it.getAnnotation(RpcMethod::class.java) != null}
+                    .map { it as ExecutableElement }
+                for(method in methods){
+                    val methodSpec = FunSpec.builder(method.simpleName.toString())
+                    methodSpec.addTypeVariables(method.typeParameters.map { it.asTypeVariableName() })
+                    methodSpec.returns(method.returnType.asTypeName().javaToKotlinType())
+
+                    for(parameter in method.parameters){
+                        methodSpec.addParameter(parameter.simpleName.toString(), parameter.toTypeName())
+                    }
+
+                    methodSpec.addStatement("val result = client.write(\"${wrapperOptions.serviceName.nullIfEmpty()
+                        ?: element.simpleName}.${method.simpleName}\", RpcParams.listParams(${method.parameters.joinToString(
+                        ", "
+                    ) { it.simpleName }})).get()")
+                    methodSpec.addStatement("if(result.hasError) throw RuntimeException(result.error!!.toString())")
+
+                    if (method.returnType.kind != TypeKind.VOID) {
+                        methodSpec.addStatement("return if(result.hasResult) result.getResult()!! else throw RuntimeException(\"No result\")")
+                    }
+
+                    type.addFunction(methodSpec.build())
+                }
+
+                builder.addType(type.build())
+            }
+
+            val outputFile = File("$kaptKotlinGeneratedDir/info/laht/yajrpc/Wrappers.kt")
+            outputFile.parentFile.mkdirs()
+            builder.build().writeTo(outputFile)
+        }
+        return true
+    }
+}
+
+private fun String.nullIfEmpty() = if(this.isEmpty()) null else this
+
+//See https://github.com/square/kotlinpoet/issues/236
+fun Element.toTypeName(): TypeName =
+    asType().asTypeName().javaToKotlinType()
+
+fun TypeName.javaToKotlinType(): TypeName {
+    return if (this is ParameterizedTypeName) {
+        (rawType.javaToKotlinType() as ClassName).parameterizedBy(*typeArguments.map { it.javaToKotlinType() }.toTypedArray())
+    } else {
+        val className =
+            JavaToKotlinClassMap.INSTANCE.mapJavaToKotlin(FqName(toString()))
+                ?.asSingleFqName()?.asString()
+
+        return if (className == null) {
+            this
+        } else {
+            ClassName.bestGuess(className)
+        }
+    }
+}

--- a/yaj-rpc-tests/build.gradle
+++ b/yaj-rpc-tests/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+    id "org.jetbrains.kotlin.kapt"
+}
 
 dependencies {
     testImplementation project(':yaj-rpc')
@@ -5,4 +8,6 @@ dependencies {
     testImplementation project(':yaj-rpc-tcp')
     testImplementation project(':yaj-rpc-zmq')
     testImplementation project(':yaj-rpc-http')
+    testImplementation project(':yaj-rpc-annotation-processor')
+    kaptTest project(':yaj-rpc-annotation-processor')
 }

--- a/yaj-rpc-tests/src/test/java/info/laht/yajrpc/SampleService.java
+++ b/yaj-rpc-tests/src/test/java/info/laht/yajrpc/SampleService.java
@@ -1,9 +1,11 @@
 package info.laht.yajrpc;
 
+import info.laht.yajrpc.annotationprocessor.GenerateRpcWrapper;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@GenerateRpcWrapper
 public class SampleService implements RpcService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SampleService.class);
@@ -40,7 +42,7 @@ public class SampleService implements RpcService {
         return myClass;
     }
 
-    static class MyClass {
+    public static class MyClass {
         int i;
         double d;
         String s;

--- a/yaj-rpc-tests/src/test/kotlin/info/laht/yajrpc/AbstractTestServer.kt
+++ b/yaj-rpc-tests/src/test/kotlin/info/laht/yajrpc/AbstractTestServer.kt
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractTestServer {
@@ -47,6 +45,22 @@ abstract class AbstractTestServer {
         client.write("SampleService.greet", RpcListParams("Clint Eastwood")).get().also {
             LOG.info("Synchronous response=${it.getResult(String::class.java)}")
         }
+
+        testWrapper()
+    }
+
+    fun testWrapper(){
+        val wrapper = SampleServiceWrapper(client)
+
+        wrapper.returnNothing()
+        Assertions.assertEquals(wrapper.greet("Clint Eastwood"), service.greet("Clint Eastwood"))
+
+        val clazz = SampleService.MyClass().apply {
+            i = 1
+            d = 2.0
+            s = "foo"
+        }
+        Assertions.assertEquals(wrapper.complex(clazz).d, 4.0)
 
     }
 


### PR DESCRIPTION
Hi! 
I like the concept of the library, but its biggest weakness seems to be actually invoking RPC calls. It's verbose and doesn't mesh well with autocomplete. 

My suggestion is to add an optional annotation processor module, which this PR is the working prototype of. Once annotated with `@GenerateRpcWrapper`, a service class can be invoked in a much more natural way.

Roughly speaking, old way:
```
client.write("SampleService.greet", RpcListParams("Clint Eastwood"))
```
New way:
```
wrapper.greet("Clint Eastwood")
```
The limitations that I know of are:
- Must be a Kotlin project, as this generates sources to compile
- Must have kapt enabled
- Deals poorly with nullable types
- There's a bit of confused duplication with service names between the annotation and the RpcService interface
