### PR TITLE
Optimize RpcResponse and misc cleanup

### DIFF
--- a/yaj-rpc-annotation-processor/src/main/kotlin/info/laht/yajrpc/annotationprocessor/Processor.kt
+++ b/yaj-rpc-annotation-processor/src/main/kotlin/info/laht/yajrpc/annotationprocessor/Processor.kt
@@ -27,9 +27,11 @@ annotation class GenerateRpcWrapper(val serviceName : String = "")
 @SupportedAnnotationTypes("info.laht.yajrpc.annotationprocessor.GenerateRpcWrapper")
 @SupportedOptions(GenerateWrappersProcessor.KAPT_KOTLIN_GENERATED_OPTION_NAME)
 class GenerateWrappersProcessor : AbstractProcessor() {
+
     companion object {
         const val KAPT_KOTLIN_GENERATED_OPTION_NAME = "kapt.kotlin.generated"
     }
+
     override fun process(annotations: MutableSet<out TypeElement>, roundEnv: RoundEnvironment): Boolean {
         val elements = roundEnv.getElementsAnnotatedWith(GenerateRpcWrapper::class.java)
         val kaptKotlinGeneratedDir = processingEnv.options[KAPT_KOTLIN_GENERATED_OPTION_NAME] ?: run {

--- a/yaj-rpc-tests/src/test/java/info/laht/yajrpc/SampleService.java
+++ b/yaj-rpc-tests/src/test/java/info/laht/yajrpc/SampleService.java
@@ -71,9 +71,16 @@ public class SampleService implements RpcService {
     }
 
     public static class MyClass {
-        int i;
-        double d;
-        String s;
+
+        public int i;
+        public double d;
+        public String s;
+
+        public MyClass(int i, double d, String s) {
+            this.i = i;
+            this.d = d;
+            this.s = s;
+        }
 
         @Override
         public String toString() {

--- a/yaj-rpc/src/main/kotlin/info/laht/yajrpc/RpcResponse.kt
+++ b/yaj-rpc/src/main/kotlin/info/laht/yajrpc/RpcResponse.kt
@@ -24,7 +24,16 @@
 
 package info.laht.yajrpc
 
+import com.google.gson.JsonElement
 import com.google.gson.annotations.SerializedName
+
+data class RpcResponseOut(
+        private val id: Any,
+        private val result: Any?
+) {
+
+    private val jsonrpc = JSON_RPC_VERSION
+}
 
 /**
  *
@@ -37,7 +46,7 @@ class RpcResponse internal constructor() {
 
     val id: Any = NO_ID
     val error: RpcError? = null
-    private val result: Any? = null
+    private val result: JsonElement? = null
 
     val isVoid: Boolean
         get() = hasResult && result == null
@@ -54,19 +63,12 @@ class RpcResponse internal constructor() {
 
     fun <T> getResult(clazz: Class<T>): T? {
         return if (hasResult && !isVoid) {
-           YAJRPC.fromJson(YAJRPC.toJson(result!!), clazz)
+           YAJRPC.fromJson(result!!, clazz)
         } else null
     }
 
     override fun toString(): String {
+        @Suppress("IMPLICIT_CAST_TO_ANY")
         return "RPCResponse{" + "$JSON_RPC_IDENTIFIER=$version, $ID_KEY=$id, response=${(if (hasError) error else result)}}"
     }
-}
-
-data class RpcResponseOut(
-        private val id: Any,
-        private val result: Any?
-) {
-
-    private val jsonrpc = JSON_RPC_VERSION
 }

--- a/yaj-rpc/src/main/kotlin/info/laht/yajrpc/YAJRPC.kt
+++ b/yaj-rpc/src/main/kotlin/info/laht/yajrpc/YAJRPC.kt
@@ -87,5 +87,3 @@ object YAJRPC {
     }
 
 }
-
-

--- a/yaj-rpc/src/main/kotlin/info/laht/yajrpc/net/RpcClient.kt
+++ b/yaj-rpc/src/main/kotlin/info/laht/yajrpc/net/RpcClient.kt
@@ -78,9 +78,8 @@ interface RpcClient : Closeable {
  */
 abstract class AbstractRpcClient : RpcClient {
 
+    private val executor = Executors.newSingleThreadExecutor()
     private val callbacks = mutableMapOf<String, Consumer<RpcResponse>>()
-
-    private val executor = Executors.newSingleThreadExecutor();
 
     override fun notify(methodName: String, params: RpcParams) {
         internalWrite(RpcRequestOut(methodName, params).toJson())


### PR DESCRIPTION
@ligi Please have a quick look at the changes to RpcResponse.kt.

I initialliy wanted to make the class generic, but gson struggles with nested generics and is unable to deserialize complex objects.. So I turned to this optimization instead. The old approach was quite inefficient. 